### PR TITLE
fix(api): prevent 500 on invoice delete by importing exceptions

### DIFF
--- a/classes/Modules/Api/Resource/DocumentInvoiceResource.php
+++ b/classes/Modules/Api/Resource/DocumentInvoiceResource.php
@@ -2,6 +2,8 @@
 
 namespace Xentral\Modules\Api\Resource;
 
+use Exception;
+use InvalidArgumentException;
 use Xentral\Components\Database\SqlQuery\DeleteQuery;
 use Xentral\Components\Database\SqlQuery\SelectQuery;
 use Xentral\Components\Database\SqlQuery\UpdateQuery;


### PR DESCRIPTION
# Summary
Fixes HTTP 500 on `DELETE /v1/belege/rechnungen/{id}` by adding missing `Exception` and `InvalidArgumentException` imports in `DocumentInvoiceResource`.

# Validation
A/B tested:
- without imports: 500 (`Unexpected error`)
- with imports: regular API response (no server crash)

# Scope
Single-file change, no business logic modification.