### PR TITLE
fix: POST /v1/dateien stichwoerter variable scoping bug (#245)

### DIFF
--- a/classes/Modules/Api/Controller/Version1/FileController.php
+++ b/classes/Modules/Api/Controller/Version1/FileController.php
@@ -124,8 +124,8 @@ class FileController extends AbstractController
             throw new BadRequestException('Required property "file_content" is missing.');
         }
 
-        if (is_array($input['stichwoerter'])) {
-            $stichwoerter = array();
+        $stichwoerter = array();
+        if (isset($input['stichwoerter']) && is_array($input['stichwoerter'])) {
             $erp = $this->legacyApi->app->erp;
             $DB = $this->legacyApi->app->DB;
             foreach ($input['stichwoerter'] as $stichwort_input) {


### PR DESCRIPTION
## Summary

- Fix variable scoping bug in `FileController::createAction()` where `$stichwoerter` was only initialized inside the `if`-block but used in the `foreach` outside it
- Add `isset()` check to prevent PHP Notice on missing array key

## Problem

When uploading files via `POST /v1/dateien` with `stichwoerter` parameters for object binding (e.g. attaching a file to an Auftrag), the stichwoerter are silently ignored. The file is created but without any object association. Files created through the PHP UI work correctly.

## Root Cause

`$stichwoerter = array()` was defined on line 128 inside the `if (is_array(...))` block, but the `foreach ($stichwoerter as ...)` on line 176 runs outside that block. When the `if` condition is false, `$stichwoerter` is undefined. The resulting PHP Warning is masked by `error_reporting(E_ERROR)` in `www/api/index.php`.

## Fix (2 lines changed)

```diff
-        if (is_array($input['stichwoerter'])) {
-            $stichwoerter = array();
+        $stichwoerter = array();
+        if (isset($input['stichwoerter']) && is_array($input['stichwoerter'])) {
```

## Test plan

- [ ] Upload file via API with stichwoerter — verify `datei_stichwoerter` table entry created
- [ ] Upload file via API without stichwoerter — verify no error, file created normally
- [ ] Upload file via UI — verify unchanged behavior

Fixes #245