### PR TITLE
feat: _custom.php Support fuer Page-Controller im Player

### DIFF
--- a/phpwf/class.player.php
+++ b/phpwf/class.player.php
@@ -173,9 +173,19 @@ class Player {
         }
       } else {
         include_once(dirname(__DIR__)."/www/pages/".$module.".php");
-        //create dynamical an object
+        // Support _custom.php extension pattern (same as loadModule)
+        $customFile = dirname(__DIR__)."/www/pages/".$module."_custom.php";
+        if(file_exists($customFile)) {
+          include_once($customFile);
+        }
+        //create dynamical an object, prefer Custom class
         $constr = strtoupper($module[0]) . substr($module, 1);
-        if(class_exists($constr))$myApp = new $constr($this->app);
+        $constrCustom = $constr . 'Custom';
+        if(class_exists($constrCustom)) {
+          $myApp = new $constrCustom($this->app);
+        } elseif(class_exists($constr)) {
+          $myApp = new $constr($this->app);
+        }
       }
     }
     else {


### PR DESCRIPTION
## Summary

- Erweitert den Player (\`phpwf/class.player.php\`) um den bestehenden \`_custom.php\`-Erweiterungsmechanismus
- Page-Controller koennen jetzt update-sicher ueber \`www/pages/<modul>_custom.php\` erweitert werden
- Konsistent mit dem bestehenden Pattern in \`loadModule()\` (\`class.application_core.php\`)

Fixes #255

## Aenderung

Eine Datei, +12/-2 Zeilen in \`phpwf/class.player.php\`:

1. Nach dem Laden der Basis-Datei wird geprueft ob \`_custom.php\` existiert
2. Bei der Instanziierung wird die Custom-Klasse (\`<Modul>Custom\`) bevorzugt

## Test plan

- [ ] Ohne \`_custom.php\`: Verhalten unveraendert, alle Module laden normal
- [ ] Mit \`www/pages/ticket_custom.php\` (\`class TicketCustom extends Ticket\`): Custom-Klasse wird geladen
- [ ] Methoden-Override in Custom-Klasse funktioniert (z.B. \`ticket_edit()\`)
- [ ] \`parent::ticket_edit()\` ruft Original-Methode korrekt auf

🤖 Generated with [Claude Code](https://claude.com/claude-code)