### PR TITLE
Restore erpAPI::LoadZahlungsweiseModul() removed in PSR-3 logger cleanup

### DIFF
--- a/www/lib/class.erpapi.php
+++ b/www/lib/class.erpapi.php
@@ -3830,6 +3830,35 @@ title: 'Abschicken',
     }
   }
 
+  function LoadZahlungsweiseModul($module, $moduleId) {
+
+    $module = preg_replace('/[^a-zA-Z0-9\_]/','',$module);
+
+    if(empty($module)) {
+      return null;
+    }
+    if(strpos($module,'zahlungsweise_') === 0) {
+      $module = substr($module, 14);
+      if(empty($module)) {
+        return null;
+      }
+    }
+    if(strpos($module, '.') !== false || strpos($module, '/') !== false || strpos($module, '\\') !== false) {
+      return null;
+    }
+    $path = dirname(__DIR__).'/lib/zahlungsweisen/'.$module.'.php';
+    if(!is_file($path)) {
+      return null;
+    }
+
+    include_once $path ;
+    $classname = 'Zahlungsweise_'.$module;
+    if(!class_exists($classname)) {
+      return null;
+    }
+    return new $classname($this->app, $moduleId);
+  }
+
   // @refactor Document Komponente
   function Zahlungsweisetext($doctype,$doctypeid)
   {


### PR DESCRIPTION
## Problem

`Zahlungsweisen → Edit` and payment block processing in `Zahlungsverkehr` fail with a fatal error:

```
Fatal error: Call to undefined method erpAPI::LoadZahlungsweiseModul()
www/pages/zahlungsweisen.php:1103
```

## Root cause

The helper `LoadZahlungsweiseModul($module, $moduleId)` was added to `www/lib/class.erpapi.php` in commit [`566d884`](https://github.com/OpenXE-org/OpenXE/commit/566d884) (2025-09-29, *"verbindlichkeit, zahlungsweise, ueberweisung extended"*) and used by several callers.

Commit [`91e603d`](https://github.com/OpenXE-org/OpenXE/commit/91e603d) (2026-03-10, *"Remove legacy logging system and replace it with PSR-3 compatible Logger. Clean up related outdated classes and files."*) removed the helper from `class.erpapi.php`. Two internal callers in the same file (`Zahlungsweisetext`, `sendPaymentStatus`) were correctly migrated back to the inline `preg_replace + include + new` pattern, but **three external callers were missed**:

| File | Line | Context |
|---|---|---|
| `www/pages/zahlungsweisen.php` | 689 | `loadModule()` wrapper |
| `www/pages/zahlungsweisen.php` | 1103 | `ZahlungsweisenEdit()` — the stack trace |
| `www/pages/zahlungsverkehr.php` | 631 | Lastschrift/Überweisung block processing |

These three sites still call `$this->app->erp->LoadZahlungsweiseModul(...)`, which now fails fatally on the first execution path that reaches them.

## Fix

Restore the helper to `www/lib/class.erpapi.php` byte-for-byte from `566d884`, with one trivial style fix: the third `strpos` check now uses `!== false` for consistency with the two preceding checks. No functional impact, since the leading `preg_replace('/[^a-zA-Z0-9\_]/', '', ...)` already strips backslashes before the check runs.

Single-file change, +29 lines, no removals.

## Alternative considered

Migrating the three external callers to the same inline pattern used by the two internal sites. Rejected because it would duplicate ~15 lines of identical logic three times across two files, and the helper is the cleaner abstraction — which is presumably why it was introduced in `566d884` in the first place. The cleanup commit's intent appears to have been logger-related; removing this helper looks unintentional.

## Testing

- `php -l www/lib/class.erpapi.php` clean
- Manual: `Zahlungsweisen → Edit` opens without fatal in our deployment after applying this patch