### PR TITLE
Fix DeliveryAddressResource::insert signature mismatch (HTTP 500 on /v1/lieferadressen on PHP 8+)

### DIFF
--- a/classes/Modules/Api/Resource/DeliveryAddressResource.php
+++ b/classes/Modules/Api/Resource/DeliveryAddressResource.php
@@ -121,7 +121,7 @@ class DeliveryAddressResource extends AbstractResource
     /**
      * @inheritdoc
      */
-    public function insert($inputVars)
+    public function insert($inputVars, $inputMapping = null)
     {
         // SQL-Fehler umgehen: Field 'sprache' doesn't have a default value
         if (!isset($inputVars['abteilung'])) { $inputVars['abteilung'] = ''; }


### PR DESCRIPTION
## Summary

`DeliveryAddressResource::insert($inputVars)` overrides the parent
`AbstractResource::insert($inputVars, $inputMapping = null)` with a 1-parameter signature.

PHP 8 enforces LSP-style signature compatibility at compile time, so the class fails to load and **every request to `/v1/lieferadressen` returns HTTP 500** with the generic `Unexpected error` body — including plain reads (`GET /v1/lieferadressen?adresse=…`) that never reach the `insert()` path. The endpoint is effectively unreachable on any modern OpenXE install.

This change adds the missing optional second parameter so the override matches the parent (and the other `Resource` subclasses such as `ArticleSubscriptionResource`/`ArticleSubscriptionGroupResource`, which already declare it correctly). The function body only references `$inputVars`, so no logic change is needed.

## Reproduction

On a current OpenXE install running PHP 8+:

```
GET /www/api/index.php/v1/lieferadressen?adresse=<existing_main_address_id>
→ HTTP 500
  {"error":{"code":7499,"message":"Unexpected error","http_code":500}}
```

With `DEBUG_MODE` enabled in `/www/api/index.php` the underlying error becomes visible:

```
Compile Error: Declaration of
Xentral\Modules\Api\Resource\DeliveryAddressResource::insert($inputVars)
must be compatible with
Xentral\Modules\Api\Resource\AbstractResource::insert($inputVars, $inputMapping = null)
in classes/Modules/Api/Resource/DeliveryAddressResource.php:124
```

## Test plan

- [x] Apply the patch on a real OpenXE install running PHP 8+
- [x] Same `GET /v1/lieferadressen?adresse=<id>` now returns 200 with the documented delivery-address list (verified against an instance with 21 delivery addresses for one main customer; pagination shape matches the docs)
- [x] No code paths changed beyond the signature; existing `$inputVars` consumers unaffected