### PR TITLE
Fix list endpoints returning HTTP 404 on empty result sets

### DIFF
--- a/classes/Modules/Api/Resource/AbstractResource.php
+++ b/classes/Modules/Api/Resource/AbstractResource.php
@@ -135,10 +135,6 @@ abstract class AbstractResource
             $selectList->getBindValues()
         );
 
-        if (count($items) === 0) {
-            throw new ResourceNotFoundException();
-        }
-
         // Gesamtanzahl der Ergebnisse ermitteln
         $selectCount = clone $selectAll;
         $selectCount->resetOrderBy()->resetCols()->cols(['COUNT(*)']);

--- a/classes/Modules/Api/Resource/Result/CollectionResult.php
+++ b/classes/Modules/Api/Resource/Result/CollectionResult.php
@@ -14,15 +14,17 @@ class CollectionResult extends AbstractResult
             //throw new \CountryInvalidArgumentException('CollectionResult must contain pagination'); // @todo für GetIDs
         }
 
-        if (empty($collection)) {
-            throw new \InvalidArgumentException('CollectionResult can not be empty');
-        }
-        $firstKey = key($collection);
-        if (!is_numeric($firstKey)) {
-            throw new \InvalidArgumentException('CollectionResult can only store an index based array');
-        }
-        if (!is_array($collection[$firstKey]) || empty($collection[$firstKey])) {
-            throw new \RuntimeException('CollectionResult must contain at least one result');
+        // An empty collection is a valid list response — there's no rule
+        // that says a 0-row table must 404. Only validate the shape when
+        // the collection has entries.
+        if (!empty($collection)) {
+            $firstKey = key($collection);
+            if (!is_numeric($firstKey)) {
+                throw new \InvalidArgumentException('CollectionResult can only store an index based array');
+            }
+            if (!is_array($collection[$firstKey]) || empty($collection[$firstKey])) {
+                throw new \RuntimeException('CollectionResult must contain at least one result');
+            }
         }
 
         // @todo Sicherstellen dass Paginierung passt


### PR DESCRIPTION
## Summary

Two related bugs in `AbstractResource` → `CollectionResult` cause every list endpoint backed by a 0-row table to return **HTTP 404 "Resource not found"** instead of an empty list response. Reproducible against `/v1/belege/gutschriften` on any install where no credit notes have been created yet, and against any resource the caller has no data for.

The matching `getOne(\$id)` path keeps its 404 — a single record addressed by id legitimately either exists or doesn't. The fix targets only the list / collection paths.

## Bug 1 — `AbstractResource::getList`

```php
if (count(\$items) === 0) {
    throw new ResourceNotFoundException();
}
```

An empty list query is a valid response, not a missing resource. `getList` should return an empty `CollectionResult` instead.

## Bug 2 — `CollectionResult::__construct`

```php
if (empty(\$collection)) {
    throw new \InvalidArgumentException('CollectionResult can not be empty');
}
```

Same wrong assumption inside the result type itself. Even with bug 1 fixed, this constructor blocks empty collections and escalates the empty result to **HTTP 500** (\`Unhandled exception: CollectionResult can not be empty\`). The shape validations below it (index-based array, first item must be array) are still needed when the collection has entries — guarded by `!empty(\$collection)`.

## Reproduction

On a fresh install:

```
GET /v1/belege/gutschriften
→ HTTP 404
{\"error\":{\"code\":7452,\"http_code\":404,\"message\":\"Resource not found\"}}
```

With `DEBUG_MODE` enabled, the debug block confirms the route resolved correctly:

```
debug.router:
  controllerClass: GenericController
  controllerAction: listAction
  resourceClass: DocumentCreditNoteResource
  permission: list_credit_memos
```

The 404 fires inside `AbstractResource::getList` because `gutschrift` happens to be empty.

## After this PR

```
GET /v1/belege/gutschriften
→ HTTP 200
{\"data\":[],\"pagination\":{\"items_per_page\":20,\"items_current\":0,\"items_total\":0,\"page_current\":1,\"page_last\":0}}
```

## Test plan

- [x] Apply patch, hit a known-empty list endpoint (`/v1/belege/gutschriften`) → 200 with empty \`data\` and zeroed pagination
- [x] Populated list endpoint still works (\`/v1/belege/rechnungen?items=1\` → 200, items_total=57)
- [x] \`getOne\` for a non-existent id still returns 404 (\`/v1/belege/rechnungen/9999\` → 404)
- [x] \`getOne\` for an existing id still returns 200