### PR TITLE
location: fix broken redirects behind reverse proxy (https://host:80)

### DIFF
--- a/www/lib/class.location.php
+++ b/www/lib/class.location.php
@@ -37,8 +37,15 @@ class Location
       if($_SERVER['SERVER_NAME'] === '_' && !empty($_SERVER['HTTP_HOST'])){
         // Sonderfall für Nginx mit Servername "_"
         $server = $REQUEST_PROTOCOL.'://'.$_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI'];
+      }elseif(!empty($_SERVER['HTTP_HOST'])){
+        // HTTP_HOST enthält Host und ggf. Port so, wie der Client sie adressiert hat.
+        // SERVER_PORT wäre hinter einem Reverse Proxy der interne Port (z.B. 80) und
+        // ergäbe mit https kaputte Redirects wie https://host:80/...
+        $server = $REQUEST_PROTOCOL.'://'.$_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI'];
       }else{
-        $server = $REQUEST_PROTOCOL.'://'.$_SERVER['SERVER_NAME'].':'.$_SERVER['SERVER_PORT'].$_SERVER['REQUEST_URI'];
+        $server = $REQUEST_PROTOCOL.'://'.$_SERVER['SERVER_NAME'].
+          ($_SERVER['SERVER_PORT'] != 80 && $_SERVER['SERVER_PORT'] != 443 ? ':'.$_SERVER['SERVER_PORT'] : '').
+          $_SERVER['REQUEST_URI'];
       }
     }elseif(!empty($_SERVER['REQUEST_URI']) && !empty($_SERVER['SERVER_ADDR']) &&
       !empty($_SERVER['SCRIPT_NAME']) && $_SERVER['SERVER_ADDR']!=='::1' && strpos($_SERVER['SERVER_SOFTWARE'],'nginx')===false


### PR DESCRIPTION
## Problem

`Location::__construct()` (www/lib/class.location.php) baut die absolute Redirect-URL aus `SERVER_NAME` und `SERVER_PORT` und haengt den Port **immer** an:

```php
$server = $REQUEST_PROTOCOL.'://'.$_SERVER['SERVER_NAME'].':'.$_SERVER['SERVER_PORT'].$_SERVER['REQUEST_URI'];
```

Hinter einem TLS-terminierenden Reverse Proxy (nginx/openresty → Backend auf Port 80, `X-Forwarded-Proto: https`) zeigt damit jeder `Location:`-Redirect (z.B. nach Artikel einlagern) auf:

```
https://host:80/www/index.php?module=artikel&action=lager&id=...&msgs=...
```

Der Browser macht einen TLS-Handshake gegen den Klartext-HTTP-Port → SSL-Fehler. Fuer den Anwender sieht das wie ein ungueltiges Zertifikat aus, obwohl Zertifikat und Server in Ordnung sind.

## Fix

`HTTP_HOST` bevorzugen — enthaelt Host und ggf. Port exakt so, wie der Client sie adressiert hat (gleiches Muster wie der bereits vorhandene Nginx-`"_"`-Sonderfall eine Zeile darueber). Fallback auf `SERVER_NAME` nur noch, wenn `HTTP_HOST` fehlt, und dort `SERVER_PORT` nur bei Nicht-Standard-Ports anhaengen (gleiches Muster wie der `SERVER_ADDR`-Zweig darunter).

## Verifikation

Standalone-Test der Klasse mit gemocktem `$app`, 8 Szenarien (`getServer()` + `getLocationUrl()`):

| Szenario | vorher | nachher |
|---|---|---|
| Proxy: XFP=https, Backend-Port 80 | `https://host:80/...` ❌ | `https://host/...` ✅ |
| Direkt HTTP :80 | `http://host:80/...` | `http://host/...` ✅ |
| Direkt HTTPS :443 | `https://host:443/...` | `https://host/...` ✅ |
| Nicht-Standard-Port 8080 | `http://host:8080/...` ✅ | `http://host:8080/...` ✅ |
| Ohne HTTP_HOST (Fallback) :80 / :8080 | `:80` ❌ / `:8080` ✅ | ohne Port ✅ / `:8080` ✅ |
| Nginx `SERVER_NAME="_"` | ✅ | ✅ (unveraendert) |

`php -l` sauber. Reproduziert und verifiziert auf produktiver Instanz hinter openresty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)